### PR TITLE
Fix #2

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jar
 *.war
 *.ear
+/bin/

--- a/.project
+++ b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.pathvisio.typeconverter</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: org.pathvisio.typeconverter
 Bundle-SymbolicName: org.pathvisio.typeconverter
 Bundle-Version: 1.1.0
 Bundle-Activator: org.pathvisio.typeconverter.Activator
-Import-Package: org.osgi.framework;version="1.5.0"
 Require-Bundle: org.pathvisio.core;bundle-version="3.0.0",
  org.pathvisio.desktop;bundle-version="3.0.0",
  org.pathvisio.gui;bundle-version="3.0.0"
+Import-Package: org.osgi.framework;version="1.5.0"
+Export-Package: org.pathvisio.typeconverter

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 org.pathvisio.typeconverter
 ===========================
 
-Enables the conversion of pathway elements into other types (e.g. Label into Metabolite)
+This plugin for Pathvisio enables the conversion of pathway elements into other types (e.g. Label into Metabolite).

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,3 @@
+source.. = src/
+bin.includes = META-INF/,\
+               .

--- a/src/org/pathvisio/typeconverter/TypeConverter.java
+++ b/src/org/pathvisio/typeconverter/TypeConverter.java
@@ -103,10 +103,14 @@ public class TypeConverter implements Plugin, PathwayElementMenuHook {
 				DataNodeToDataNode action5 = new DataNodeToDataNode((Graphics)e, DataNodeType.RNA);
 				refMenu.add(action5);
 			}
-			DataNodeToLabel action6 = new DataNodeToLabel((Graphics)e, ObjectType.LABEL );
-			refMenu.add(action6);
+			if(!DataNodeType.byName(dnType).equals(ObjectType.LABEL)) {
+				DataNodeToLabel action6 = new DataNodeToLabel((Graphics)e, ObjectType.LABEL);
+				refMenu.add(action6);
+			}
+//			DataNodeToLabel action7 = new DataNodeToLabel((Graphics)e, ObjectType.LABEL );
+//			refMenu.add(action7);
 			menu.add(refMenu);
+			
 		}
 	}
-
 }


### PR DESCRIPTION
Added a call in the typeconverter.java script, to enable the change of DataNodes to Labels (which was already defined inDatanodetoLabel.java ).

@mkutmon Could you please check if it also works for you (and there are no double change to label tabs in the menu ;)....)? Thank you :).